### PR TITLE
fix(ci): replace goto-bus/setup-zig with mlugg/setup-zig

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Zig
-        uses: goto-bus-stop/setup-zig@v2
+        uses: mlugg/setup-zig@v2
         with:
           version: 0.15.0
 

--- a/.github/workflows/test-bindings.yml
+++ b/.github/workflows/test-bindings.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Zig
-        uses: goto-bus/setup-zig@v2
+        uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
 


### PR DESCRIPTION
## Summary

- Replace dead `goto-bus/setup-zig@v2` (404 typo) with `mlugg/setup-zig@v2` in `.github/workflows/test-bindings.yml`
- Migrate `goto-bus-stop/setup-zig@v2` to `mlugg/setup-zig@v2` in `.github/workflows/release.yml` for consistency
- `mlugg/setup-zig` is actively maintained (231 stars, last push 2026-01-19) with explicit Zig 0.16 support

Closes #28

Unblocks: #27 (BUG-001-BF16), #26 (BENCH-007b v2), #25 (race execution order)