### PR TITLE
fix(bindings): Rust gf16_t naming lint under -D warnings

### DIFF
--- a/rust/goldenfloat-sys/src/lib.rs
+++ b/rust/goldenfloat-sys/src/lib.rs
@@ -18,6 +18,7 @@
 
 #![no_std]
 #![allow(non_snake_case)]
+#![allow(non_camel_case_types)]
 
 use core::ffi::c_char;
 


### PR DESCRIPTION
## Summary

- Add `#![allow(non_camel_case_types)]` to `goldenfloat-sys/src/lib.rs`
- FFI bindings mirror C type names (`gf16_t`, etc.) — standard rustc-recommended approach for bindgen-style crates
- Fixes `cargo clippy -- -D warnings` failure: `error: type gf16_t should have an upper camel case name`

Closes #35