### PR TITLE
fix(bindings): add cpp/include to CMake include directories

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -22,6 +22,7 @@ endif()
 
 # Include directory for header-only wrapper
 include_directories(
+    "${CMAKE_SOURCE_DIR}/include"
     "${CMAKE_SOURCE_DIR}/../src/c"
     "${CMAKE_SOURCE_DIR}/../../src/c"
 )


### PR DESCRIPTION
## Summary

- Add `${CMAKE_SOURCE_DIR}/include` to `cpp/CMakeLists.txt` include_directories
- Without this, `#include <goldenfloat/gf16.hpp>` fails because the compiler cannot find the header
- The C header `gf16.h` was already reachable via `src/c` include path

Closes #36