### PR TITLE
fix(core): gf16_from_f32(NaN) returns NaN instead of +inf

### DIFF
--- a/src/c_abi.zig
+++ b/src/c_abi.zig
@@ -285,6 +285,10 @@ test "C-ABI: gf16_is_nan and gf16_is_inf" {
 
     const zero = gf16_from_f32(0.0);
     try std.testing.expect(gf16_is_zero(zero));
+
+    const nan_val = gf16_from_f32(std.math.nan(f32));
+    try std.testing.expect(gf16_is_nan(nan_val));
+    try std.testing.expect(!gf16_is_inf(nan_val));
 }
 
 test "C-ABI: gf16_phi_quantize" {

--- a/src/formats/golden_float16.zig
+++ b/src/formats/golden_float16.zig
@@ -88,7 +88,11 @@ pub const GF16 = packed struct(u16) {
     pub fn fromF32(v: f32) GF16 {
         if (v == 0.0) return .{ .mant = 0, .exp = 0, .sign = 0 };
 
-        if (!std.math.isFinite(v)) {
+        if (std.math.isNan(v)) {
+            return .{ .mant = 1, .exp = 0x3F, .sign = 0 };
+        }
+
+        if (std.math.isInf(v)) {
             return .{ .mant = 0, .exp = 0x3F, .sign = @intFromBool(v < 0) };
         }
 


### PR DESCRIPTION
## Summary

- **Root cause:** `GF16.fromF32()` used `!std.math.isFinite(v)` as a single branch for all non-finite values, always setting `mant=0` (infinity encoding). For NaN input, `v < 0` evaluates to `false` (IEEE 754), so the result was `{mant:0, exp:0x3F, sign:0}` = positive infinity (`0x7E00`) instead of NaN (`0x7E01`).
- **Fix:** Split the non-finite branch into separate `isNan(v)` → `GF16_NAN (0x7E01)` and `isInf(v)` → signed infinity checks.
- **Added C-ABI test** for NaN round-trip: `gf16_from_f32(nan)` → `gf16_is_nan() == true`.

This is a **Z-side bug** (affects all bindings: Python, Rust, Go, C++). The fix is in `src/formats/golden_float16.zig`.

Closes #38