### PR TITLE
fix(cpp): add include/ to CMakeLists for gf16.hpp resolution

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -22,6 +22,7 @@ endif()
 
 # Include directory for header-only wrapper
 include_directories(
+    "${CMAKE_SOURCE_DIR}/include"
     "${CMAKE_SOURCE_DIR}/../src/c"
     "${CMAKE_SOURCE_DIR}/../../src/c"
 )


### PR DESCRIPTION
## Summary

- Add `${CMAKE_SOURCE_DIR}/include` to `include_directories()` in `cpp/CMakeLists.txt`
- Fixes build failure where `#include <goldenfloat/gf16.hpp>` could not be resolved

## Root Cause

The test file `cpp/tests/test_gf16.cpp` includes `<goldenfloat/gf16.hpp>`, but the `cpp/include/` directory was not in the CMake include path. The C header `gf16.h` was properly included via `../src/c`, but the C++ wrapper directory itself was missing.

Closes #36