### PR TITLE
feat: trinity_constants.zig — IGLA-GF16 Module 1 (Fibonacci arch, φ constants)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -111,8 +111,21 @@ pub fn build(b: *std.Build) void {
 
     const run_tests = b.addRunArtifact(formats_tests);
     const run_transcendent_tests = b.addRunArtifact(transcendent_tests);
+
+    const trinity_tests_root = b.createModule(.{
+        .root_source_file = b.path("src/trinity_constants.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const trinity_tests = b.addTest(.{
+        .name = "trinity-tests",
+        .root_module = trinity_tests_root,
+    });
+    const run_trinity_tests = b.addRunArtifact(trinity_tests);
+
     const test_step = b.step("test", "Run all tests");
     test_step.dependOn(&run_tests.step);
     test_step.dependOn(&run_transcendent_tests.step);
+    test_step.dependOn(&run_trinity_tests.step);
     test_step.dependOn(&run_c_abi_tests.step);
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -61,6 +61,9 @@ pub const ternary_primitives = @import("src/ternary/bigint.zig");
 /// Sacred constants (φ, e, π)
 pub const math = @import("src/math/constants.zig");
 
+/// Trinity constants for IGLA-GF16 architecture
+pub const trinity = @import("src/trinity_constants.zig");
+
 // ═══════════════════════════════════════════════════════════════════════
 // TRINITY CONSTANTS (re-exported for convenience)
 // ═════════════════════════════════════════════════════════════════════════════════

--- a/src/trinity_constants.zig
+++ b/src/trinity_constants.zig
@@ -1,0 +1,104 @@
+//! Trinity Constants — φ-derived physics for IGLA-GF16 architecture
+//!
+//! Module 1 from IGLA-GF16 spec (issue #3).
+//!
+//! All hyperparameters derived from Trinity φ-algebra:
+//!   PHI = (1 + √5) / 2 ≈ 1.6180339887498948
+//!   PHI^2 + PHI^(-2) = 3  (Trinity Identity)
+//!   ALPHA_PHI = PHI^(-3) / 2 ≈ 0.118034
+
+const std = @import("std");
+
+pub const PHI: f64 = 1.6180339887498948482;
+
+pub const PHI_SQ: f64 = PHI * PHI;
+
+pub const PHI_INV: f64 = 1.0 / PHI;
+
+pub const PHI_INV_SQ: f64 = 1.0 / PHI_SQ;
+
+pub const TRINITY: f64 = PHI_SQ + PHI_INV_SQ;
+
+pub const ALPHA_PHI: f64 = 1.0 / (PHI * PHI * PHI) / 2.0;
+
+pub const ALPHA_PHI_X_PHI_INV: f64 = ALPHA_PHI * PHI_INV;
+
+pub const ALPHA_PHI_X_PHI_INV_SQ: f64 = ALPHA_PHI * PHI_INV_SQ;
+
+pub const ALPHA_PHI_X_PHI_INV_3: f64 = ALPHA_PHI * PHI_INV_SQ * PHI_INV;
+
+pub const GF16_MANT_EXP_RATIO: f64 = 9.0 / 6.0;
+
+pub const ALPHA_GF16: f64 = PHI - GF16_MANT_EXP_RATIO;
+
+pub fn fib(comptime n: comptime_int) comptime_int {
+    if (n <= 1) return n;
+    return fib(n - 1) + fib(n - 2);
+}
+
+pub const FIBONACCI = [_]comptime_int{
+    fib(0),  fib(1),  fib(2),  fib(3),  fib(4),
+    fib(5),  fib(6),  fib(7),  fib(8),  fib(9),
+    fib(10), fib(11), fib(12), fib(13), fib(14),
+    fib(15), fib(16), fib(17), fib(18), fib(19),
+    fib(20), fib(21), fib(22), fib(23), fib(24),
+};
+
+pub const D_MODEL: comptime_int = fib(12); // 144
+pub const N_HEADS: comptime_int = fib(6); // 8
+pub const D_HEAD: comptime_int = D_MODEL / N_HEADS; // 18
+pub const D_FFN: comptime_int = fib(13); // 233
+pub const N_LAYERS: comptime_int = 7;
+pub const VOCAB: comptime_int = 50257;
+
+comptime {
+    if (!(TRINITY >= 2.9999 and TRINITY <= 3.0001)) {
+        @compileError("Trinity identity violation: PHI^2 + PHI^(-2) must equal 3");
+    }
+    if (!(@abs(ALPHA_GF16 - ALPHA_PHI) < 0.001)) {
+        @compileError("GF16 alpha_phi mismatch");
+    }
+}
+
+test "trinity: PHI^2 + PHI^(-2) = 3" {
+    try std.testing.expectApproxEqAbs(@as(f64, 3.0), TRINITY, 1e-12);
+}
+
+test "trinity: PHI^2 = PHI + 1" {
+    try std.testing.expectApproxEqAbs(PHI + 1.0, PHI_SQ, 1e-12);
+}
+
+test "trinity: ALPHA_PHI = 0.118034" {
+    try std.testing.expectApproxEqAbs(@as(f64, 0.118034), ALPHA_PHI, 1e-4);
+}
+
+test "trinity: GF16 mant/exp ratio = 1.5, deviation from PHI = ALPHA_PHI" {
+    try std.testing.expectApproxEqAbs(@as(f64, 1.5), GF16_MANT_EXP_RATIO, 1e-10);
+    try std.testing.expectApproxEqAbs(ALPHA_PHI, ALPHA_GF16, 1e-3);
+}
+
+test "trinity: architecture dimensions from Fibonacci" {
+    try std.testing.expectEqual(@as(comptime_int, 144), D_MODEL);
+    try std.testing.expectEqual(@as(comptime_int, 8), N_HEADS);
+    try std.testing.expectEqual(@as(comptime_int, 18), D_HEAD);
+    try std.testing.expectEqual(@as(comptime_int, 233), D_FFN);
+}
+
+test "trinity: D_FFN ≈ D_MODEL × PHI" {
+    const ratio = @as(f64, @floatFromInt(D_FFN)) / @as(f64, @floatFromInt(D_MODEL));
+    try std.testing.expectApproxEqAbs(PHI, ratio, 0.01);
+}
+
+test "trinity: Fibonacci sequence" {
+    try std.testing.expectEqual(@as(comptime_int, 0), FIBONACCI[0]);
+    try std.testing.expectEqual(@as(comptime_int, 1), FIBONACCI[1]);
+    try std.testing.expectEqual(@as(comptime_int, 144), FIBONACCI[12]);
+    try std.testing.expectEqual(@as(comptime_int, 233), FIBONACCI[13]);
+}
+
+test "trinity: weight init sector constants" {
+    try std.testing.expect(ALPHA_PHI > 0.1 and ALPHA_PHI < 0.2);
+    try std.testing.expect(ALPHA_PHI_X_PHI_INV > 0.05 and ALPHA_PHI_X_PHI_INV < 0.1);
+    try std.testing.expect(ALPHA_PHI_X_PHI_INV_SQ > 0.03 and ALPHA_PHI_X_PHI_INV_SQ < 0.06);
+    try std.testing.expect(ALPHA_PHI_X_PHI_INV_3 > 0.01 and ALPHA_PHI_X_PHI_INV_3 < 0.04);
+}


### PR DESCRIPTION
## Summary

Implements Module 1 from issue #3 (IGLA-GF16 architecture):

**New file: `src/trinity_constants.zig`**
- `PHI`, `PHI_SQ`, `PHI_INV`, `PHI_INV_SQ`, `TRINITY` identity constants
- `ALPHA_PHI = φ⁻³/2 ≈ 0.118034` — matches PDG2024 strong coupling α_s(mZ)
- GF16 format proof: `mant/exp = 9/6 = 1.5`, deviation `φ - 1.5 = α_φ`
- Fibonacci sequence array (F(0)..F(24))
- Architecture dimensions: `d_model=144`, `n_heads=8`, `d_ffn=233`, `d_head=18`
- 4 weight-init sector constants: gauge/higgs/lepton/cosmology
- Compile-time Trinity identity verification
- 8 unit tests

**Also registered in `build.zig`** (trinity-tests step) and **`root.zig`** (`pub const trinity`).

Closes #4 (FMA constants base), references #3 (Module 1/7 complete).