### PR TITLE
fix(bf16): rewrite encoder/decoder as standard IEEE 754 bit ops

### DIFF
--- a/src/formats/formats_root.zig
+++ b/src/formats/formats_root.zig
@@ -173,63 +173,11 @@ fn fp16ToF32(x: u16) f32 {
 
 // Software bf16 encode/decode (Brain Float 16)
 fn f32ToBf16(a: f32) u16 {
-    if (a == 0) return 0;
-    if (std.math.isInf(a)) return 0x7F80; // Infinity (all ones)
-    if (std.math.isNan(a)) return 0x7FC0; // NaN
-
-    const sign_bit: u16 = if (a < 0) 0x8000 else 0;
-    const abs_a = if (a < 0) -a else a;
-
-    const frexp_result = std.math.frexp(abs_a);
-    const m_val = frexp_result.significand;
-    var e = frexp_result.exponent - 127;
-
-    if (e < -7) {
-        // Denormalized range -> flush to zero
-        return sign_bit;
-    }
-
-    e = @min(e, 7);
-    if (e <= 0 and m_val < 0.5) {
-        return sign_bit; // Subnormal -> zero
-    }
-
-    const mant_f = (m_val - 1.0) * 256.0; // 2^8
-    var mant_i = @as(i32, @intFromFloat(mant_f));
-
-    if (mant_i == 256) {
-        mant_i = 255;
-        e += 1;
-        if (e >= 7) return 0x7F80; // Overflow
-    }
-
-    const mant_bits: u16 = @as(u16, @intCast(mant_i)) & 0x00FF;
-    const e_bits: u16 = @as(u16, @intCast(e)) << 7;
-
-    return sign_bit | e_bits | mant_bits;
+    return @intCast(@as(u32, @bitCast(a)) >> 16);
 }
 
 fn bf16ToF32(x: u16) f32 {
-    if (x == 0) return 0.0;
-    if (x == 0x8000) return -0.0;
-
-    const sign = @as(i32, (x >> 15) & 0x1);
-    const e = @as(i32, (x >> 7) & 0x7F);
-    const m = @as(i32, x & 0x00FF);
-
-    if (e == 0) {
-        // Denormalized: value = m * 2^(-126)
-        const frac = @as(f32, @floatFromInt(m)) / 256.0;
-        const exp = @as(f32, @floatFromInt(e - 1 - 127));
-        const val = frac * std.math.pow(f32, 2.0, exp);
-        return if (sign != 0) -val else val;
-    } else {
-        // Normal: value = (1 + m/256) * 2^(e-127)
-        const frac = @as(f32, @floatFromInt(m)) / 256.0;
-        const exp = @as(f32, @floatFromInt(e - 127));
-        const val = (1.0 + frac) * std.math.pow(f32, 2.0, exp);
-        return if (sign != 0) -val else val;
-    }
+    return @bitCast(@as(u32, x) << 16);
 }
 
 // ═══════════════════════════════════════════════════════════════════
@@ -587,4 +535,43 @@ test "formatBytes" {
     try std.testing.expectEqual(@as(usize, 4), formatBytes(.fp32));
     try std.testing.expectEqual(@as(usize, 2), formatBytes(.gf16));
     try std.testing.expectEqual(@as(usize, 1), formatBytes(.ternary));
+}
+
+test "BF16: roundtrip 1.0" {
+    const bf16 = f32ToBf16(1.0);
+    try std.testing.expectEqual(@as(u16, 0x3F80), bf16);
+    const back = bf16ToF32(bf16);
+    try std.testing.expectEqual(@as(f32, 1.0), back);
+}
+
+test "BF16: roundtrip 100.0" {
+    const bf16 = f32ToBf16(100.0);
+    const back = bf16ToF32(bf16);
+    const err = @abs(back - 100.0);
+    try std.testing.expect(err < 1.0);
+}
+
+test "BF16: roundtrip 1e10" {
+    const bf16 = f32ToBf16(1e10);
+    const back = bf16ToF32(bf16);
+    const err = @abs(back - 1e10) / 1e10;
+    try std.testing.expect(err < 0.01);
+}
+
+test "BF16: roundtrip small values" {
+    const values = [_]f32{ 0.5, -0.5, 2.0, -2.0, 3.14, -3.14, 1e-10, -1e-10 };
+    for (values) |v| {
+        const bf16 = f32ToBf16(v);
+        const back = bf16ToF32(bf16);
+        const err = if (@abs(v) > 0.001) @abs(back - v) / @abs(v) else @abs(back - v);
+        try std.testing.expect(err < 0.01);
+    }
+}
+
+test "BF16: special values" {
+    try std.testing.expectEqual(@as(u16, 0x3F80), f32ToBf16(1.0));
+    try std.testing.expect(bf16ToF32(f32ToBf16(std.math.inf(f32))) > 1e30);
+    try std.testing.expect(std.math.isNan(bf16ToF32(f32ToBf16(std.math.nan(f32)))));
+    try std.testing.expectEqual(@as(u16, 0), f32ToBf16(0.0));
+    try std.testing.expectEqual(@as(u16, 0x8000), f32ToBf16(-0.0));
 }


### PR DESCRIPTION
## Summary

Replaces the broken `f32ToBf16`/`bf16ToF32` implementation with the standard 2-line bit manipulation approach.

## Bugs Fixed (#22)

1. **Exponent clamped to ±7** instead of IEEE-754 ±127
2. **Wrong mantissa width** — 8 bits instead of 7
3. **Wrong bit layout** in decoder — 7-bit exp + 8-bit mantissa instead of 8+7
4. **Wrong bias handling** in frexp path

## Fix

Standard BF16 = top 16 bits of IEEE 754 f32: `[S:1][E:8][M:7]`
- `f32ToBf16(a)` = `@bitCast(a) >> 16`  
- `bf16ToF32(x)` = `@bitCast(x << 16)`

Added 5 BF16 tests: 1.0, 100.0, 1e10, small values, special values.

Closes #22