### PR TITLE
feat(igla): IGLA-GF16 architecture verification bench (Module 7)

### DIFF
--- a/benches/igla_gf16_bench.zig
+++ b/benches/igla_gf16_bench.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+const tc = @import("../src/trinity_constants.zig");
+const jepa = @import("../src/jepa_t.zig");
+
+pub fn main() !void {
+    const writer = std.io.getStdOut().writer();
+
+    try writer.print("IGLA-GF16 Architecture Verification\n", .{});
+    try writer.print("====================================\n\n", .{});
+
+    try writer.print("Architecture:\n", .{});
+    try writer.print("  d_model  = {}  (Fib(12))\n", .{tc.D_MODEL});
+    try writer.print("  n_heads  = {}  (Fib(6))\n", .{tc.N_HEADS});
+    try writer.print("  d_head   = {}  (d_model/n_heads)\n", .{tc.D_HEAD});
+    try writer.print("  d_ffn    = {}  (Fib(13) = d_model*phi)\n", .{tc.D_FFN});
+    try writer.print("  n_layers = {}\n", .{tc.N_LAYERS});
+    try writer.print("  vocab    = {}  (GPT-2 BPE)\n\n", .{tc.VOCAB});
+
+    const total_mb = jepa.totalMB();
+    const encoder_params = jepa.encoderParams();
+    const predictor_params = jepa.predictorParams();
+    const total_params = jepa.totalParams();
+
+    try writer.print("Parameter Count:\n", .{});
+    try writer.print("  Encoder:    {d:>12} params ({d:.1} MB GF16)\n", .{ encoder_params, @as(f64, @floatFromInt(encoder_params)) * 2.0 / 1048576.0 });
+    try writer.print("  Predictor:  {d:>12} params ({d:.1} MB GF16)\n", .{ predictor_params, @as(f64, @floatFromInt(predictor_params)) * 2.0 / 1048576.0 });
+    try writer.print("  Total:      {d:>12} params ({d:.1} MB GF16)\n", .{ total_params, total_mb });
+    try writer.print("  Budget:     16.0 MB GF16 — {}\n\n", .{if (total_mb <= 16.0) "PASS" else "FAIL"});
+
+    try writer.print("Trinity Constants:\n", .{});
+    try writer.print("  PHI          = {d:.16}\n", .{tc.PHI});
+    try writer.print("  PHI^2        = {d:.16}\n", .{tc.PHI_SQ});
+    try writer.print("  1/PHI^2      = {d:.16}\n", .{tc.PHI_INV_SQ});
+    try writer.print("  Trinity      = {d:.16} (should be 3.0)\n", .{tc.TRINITY});
+    try writer.print("  ALPHA_PHI    = {d:.16} (= phi - 1.5)\n", .{tc.ALPHA_PHI});
+    try writer.print("  phi-split    = {d:.3} (encoder/predictor)\n\n", .{jepa.PhiSplit});
+
+    try writer.print("Proofs:\n", .{});
+    const trinity_err = @abs(tc.TRINITY - 3.0);
+    try writer.print("  [1] Trinity Identity  |phi^2+1/phi^2 - 3| = {e}  {}\n", .{ trinity_err, if (trinity_err < 1e-12) "PASS" else "FAIL" });
+    const fib_proof = @as(f64, @floatFromInt(tc.D_MODEL)) * tc.PHI;
+    const fib_err = @abs(fib_proof - @as(f64, @floatFromInt(tc.D_FFN)));
+    try writer.print("  [5] Fib proof  144*phi = {d:.2} vs d_ffn={d}  |err|={e}  {}\n\n", .{ fib_proof, @as(f64, @floatFromInt(tc.D_FFN)), fib_err, if (fib_err < 0.1) "PASS" else "FAIL" });
+}

--- a/build.zig
+++ b/build.zig
@@ -164,4 +164,17 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_phi_attention_tests.step);
     test_step.dependOn(&run_trinity_init_tests.step);
     test_step.dependOn(&run_jepa_t_tests.step);
+
+    const igla_bench_module = b.createModule(.{
+        .root_source_file = b.path("benches/igla_gf16_bench.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const igla_bench = b.addExecutable(.{
+        .name = "igla_gf16_bench",
+        .root_module = igla_bench_module,
+    });
+    const run_igla_bench = b.addRunArtifact(igla_bench);
+    const igla_bench_step = b.step("bench-igla", "Run IGLA-GF16 architecture verification (Module 7)");
+    igla_bench_step.dependOn(&run_igla_bench.step);
 }


### PR DESCRIPTION
## Summary

Completes IGLA-GF16 implementation with Module 7: architecture verification benchmark.

### Module 7: Benchmark (`benches/igla_gf16_bench.zig`)
- `zig build bench-igla` — prints full architecture verification
- Parameter count: encoder (6 layers) + predictor (3 layers) + total in MB GF16
- Trinity Identity proof: `|φ²+1/φ² - 3| < 1e-12`
- Fibonacci proof: `144×φ = 232.99 ≈ 233` (|err| < 0.1)
- Budget check: total model ≤ 16 MB GF16

### All 7 Modules Now Complete
| Module | File | Status |
|--------|------|--------|
| 1. Trinity Constants | `src/trinity_constants.zig` | ✅ PR #59 |
| 2. GF16 Format Proof | (whitepaper docs) | N/A — documentation |
| 3. φ-Sparse Attention | `src/phi_attention.zig` | ✅ PR #61 |
| 4. Trinity Weight Init | `src/trinity_init.zig` | ✅ PR #61 |
| 5. φ-LR Schedule | `src/trinity_constants.zig` | ✅ PR #59 |
| 6. JEPA-T Predictor | `src/jepa_t.zig` | ✅ PR #61 |
| 7. Benchmarks | `benches/igla_gf16_bench.zig` | ✅ This PR |

Closes #3